### PR TITLE
tsconfig のエラー解消

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "noImplicitAny": false,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": []
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,5 @@
+// 「color-name の型定義がないよ」と言っているが、
+// こちらが使用するために追加したものでもないので、types を追加して型定義をみないようにした。
 {
   "compilerOptions": {
     "target": "ESNEXT",


### PR DESCRIPTION
「型定義がないですよ」と怒っていたが、こちらが使用するために追加したものでもないので、types のオプションを追加して型定義を見ないようにした。

* 問題の型定義は 「color-name」というもの
* node_modules の中の @types にいる